### PR TITLE
feat: Add types for chapter 3.1

### DIFF
--- a/haskell/learn-haskell-by-blog-generator/3.1.hs
+++ b/haskell/learn-haskell-by-blog-generator/3.1.hs
@@ -4,15 +4,31 @@
 -- wrapHtml content = "<html><body>" <> content <> "</body></html>"
 
 
+html_ :: String -> String
 html_ content = "<html>" <> content <> "</html>"
+
+head_ :: String -> String
 head_ content = "<head>" <> content <> "</head>"
+
+title_ :: String -> String
 title_ content = "<title>" <> content <> "</title>"
+
+body_ :: String -> String
 body_ content = "<body>" <> content <> "</body>"
 
+wrapHtml :: String -> String
 wrapHtml content = html_ (body_ content)
 
+
+makeHtml :: String -> String -> String
 makeHtml title content = html_ ((head_ (title_ title)) <> (body_ content))
 
+
+myhtml :: String
 myhtml = makeHtml "Hello Title" "Hello Body"
 
-main = putStrLn myhtml
+
+main :: IO ()
+main = do
+  putStrLn myhtml
+  putStrLn (makeHtml "TITITITLE" "BODIBODY")


### PR DESCRIPTION
## 개요
This pull request introduces several new functions to generate HTML content in a more structured way, and refactors the `main` function to include type annotations and additional output.

New HTML helper functions and refactoring:

* Added functions `html_`, `head_`, `title_`, and `body_` to generate basic HTML tags. (`haskell/learn-haskell-by-blog-generator/3.1.hs`, [haskell/learn-haskell-by-blog-generator/3.1.hsR7-R34](diffhunk://#diff-c74cbee448b1c6e25514af9f4355cec935b68de174d7a5671794d9ac92ccdbe3R7-R34))
* Refactored `wrapHtml` to use the new `html_` and `body_` functions. (`haskell/learn-haskell-by-blog-generator/3.1.hs`, [haskell/learn-haskell-by-blog-generator/3.1.hsR7-R34](diffhunk://#diff-c74cbee448b1c6e25514af9f4355cec935b68de174d7a5671794d9ac92ccdbe3R7-R34))
* Added `makeHtml` function to generate a complete HTML document with a title and body. (`haskell/learn-haskell-by-blog-generator/3.1.hs`, [haskell/learn-haskell-by-blog-generator/3.1.hsR7-R34](diffhunk://#diff-c74cbee448b1c6e25514af9f4355cec935b68de174d7a5671794d9ac92ccdbe3R7-R34))
* Updated `main` function to include type annotations and additional HTML output. (`haskell/learn-haskell-by-blog-generator/3.1.hs`, [haskell/learn-haskell-by-blog-generator/3.1.hsR7-R34](diffhunk://#diff-c74cbee448b1c6e25514af9f4355cec935b68de174d7a5671794d9ac92ccdbe3R7-R34))
## 작업 사항

## 변경점

## 스크린샷 (optional)
