### PR TITLE
:sparkles:feat: Add bst hs

### DIFF
--- a/haskell/bst/bst.hs
+++ b/haskell/bst/bst.hs
@@ -1,0 +1,44 @@
+
+-- Binary Search Tree data structure
+data BST = Empty | Node String BST BST deriving (Show, Eq)
+
+-- Function to insert an element into the BST
+insert :: String -> BST -> BST
+insert x Empty = Node x Empty Empty
+insert x (Node v left right)
+    | x < v     = Node v (insert x left) right
+    | x > v     = Node v left (insert x right)
+    | otherwise = Node v left right  -- Ignore duplicates
+
+-- Function to search for an element in the BST
+search :: String -> BST -> Bool
+search _ Empty = False
+search x (Node v left right)
+    | x == v    = True
+    | x < v     = search x left
+    | otherwise = search x right
+
+-- Function to insert a list of elements into the BST
+insertAll :: [String] -> BST -> BST
+insertAll [] bst = bst
+insertAll (x:xs) bst = insertAll xs (insert x bst)
+
+-- Example main function
+main :: IO ()
+main = do
+    -- List of 20 strings to insert into the BST
+    let elements = ["apple", "orange", "banana", "grape", "pear", "peach", "plum", "kiwi", "mango", "lime", 
+                    "lemon", "cherry", "blueberry", "strawberry", "blackberry", "raspberry", "watermelon", 
+                    "cantaloupe", "pineapple", "papaya"]
+
+    -- Create an empty BST
+    let bst = insertAll elements Empty
+
+    -- Ask user for a string to search
+    putStrLn "Enter a string to search in the BST:"
+    searchString <- getLine
+
+    -- Search for the string in the BST
+    if search searchString bst
+        then putStrLn $ searchString ++ " was found in the BST!"
+        else putStrLn $ searchString ++ " was not found in the BST."


### PR DESCRIPTION
## 개요

This pull request introduces a new Binary Search Tree (BST) implementation in Haskell, including data structure definition, insertion, and search functionalities. Additionally, it provides an example `main` function to demonstrate usage.

Key changes:

### BST Implementation:
* Added a `BST` data structure with `Empty` and `Node` constructors. (`haskell/bst/bst.hs` [haskell/bst/bst.hsR1-R44](diffhunk://#diff-e94377c504902542fb44639232dfbb83d51460008faa3479700da00bf615aea2R1-R44))
* Implemented the `insert` function to add elements to the BST, handling duplicates by ignoring them. (`haskell/bst/bst.hs` [haskell/bst/bst.hsR1-R44](diffhunk://#diff-e94377c504902542fb44639232dfbb83d51460008faa3479700da00bf615aea2R1-R44))
* Implemented the `search` function to find elements in the BST. (`haskell/bst/bst.hs` [haskell/bst/bst.hsR1-R44](diffhunk://#diff-e94377c504902542fb44639232dfbb83d51460008faa3479700da00bf615aea2R1-R44))
* Added the `insertAll` function to insert a list of elements into the BST. (`haskell/bst/bst.hs` [haskell/bst/bst.hsR1-R44](diffhunk://#diff-e94377c504902542fb44639232dfbb83d51460008faa3479700da00bf615aea2R1-R44))

### Example Usage:
* Created an example `main` function to demonstrate inserting a list of strings into the BST and searching for a user-provided string. (`haskell/bst/bst.hs` [haskell/bst/bst.hsR1-R44](diffhunk://#diff-e94377c504902542fb44639232dfbb83d51460008faa3479700da00bf615aea2R1-R44))
